### PR TITLE
bugfix/accurics_remediation_49952112007760463 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
+++ b/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
@@ -1,28 +1,37 @@
 
 resource "random_string" "bucket_suffix" {
-    upper = false
-    special = false
-    length = 32
+  upper   = false
+  special = false
+  length  = 32
 }
 
 resource "aws_s3_bucket" "bucket" {
-    bucket = "${replace(local.user_mail,"@","-")}-${random_string.bucket_suffix.result}"
+  bucket = "${replace(local.user_mail, "@", "-")}-${random_string.bucket_suffix.result}"
 
-    tags = local.default_tags
+  tags = local.default_tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = "<master_kms_key_id>"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_acl" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
-    acl    = "private"
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.bucket.id
 
-    block_public_acls   = false
-    block_public_policy = false
-    ignore_public_acls = false
-    restrict_public_buckets = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 # resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {


### PR DESCRIPTION
Server-side encryption protects data at rest. Amazon S3 encrypts each object with a unique key. As an additional safeguard, it encrypts the key itself with a key that it rotates regularly. Amazon S3 server-side encryption uses one of the strongest block ciphers available to encrypt your data using AWS KMS Customer managed key.
 In Terraform - 
 Add the 'server_side_encryption_configuration' block to ensure server side encryption is enabled. Ensure 'see_algorithm' is set to 'aws:kms' and add a 'kms_master_key_id'.