### PR TITLE
bugfix/accurics_remediation_8997323898995411 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/serverless-app/s3.tf
+++ b/demo-terraform/aws/serverless-app/s3.tf
@@ -1,16 +1,16 @@
 
 ## Create random id
 resource "random_string" "uniq" {
-    length = 32
-    special = false
-    lower = true
-    upper = false
+  length  = 32
+  special = false
+  lower   = true
+  upper   = false
 }
 
 ## Create bucket
 resource "aws_s3_bucket" "website" {
-    bucket = "${var.resource_ride}-${random_string.uniq.result}"
-    tags = local.project_tags
+  bucket = "${var.resource_ride}-${random_string.uniq.result}"
+  tags   = local.project_tags
 }
 
 ## Encrypt-Bucket (Disables for public objects)
@@ -25,83 +25,83 @@ resource "aws_s3_bucket" "website" {
 # }
 
 resource "aws_s3_bucket_versioning" "website" {
-    bucket = aws_s3_bucket.website.id
-    versioning_configuration {
-        status = "Enabled"
-    }
+  bucket = aws_s3_bucket.website.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 
 
 resource "aws_s3_bucket_acl" "website" {
-    bucket = aws_s3_bucket.website.id
-    acl    = "public-read"
+  bucket = aws_s3_bucket.website.id
+  acl    = "private"
 }
 
 ## Upload s3 site content
 
 
 module "website_content" {
-    source = "hashicorp/dir/template"
-    version = "1.0.2"
-    base_dir = var.website_folder
+  source   = "hashicorp/dir/template"
+  version  = "1.0.2"
+  base_dir = var.website_folder
 }
 
 resource "aws_s3_object" "object" {
-    for_each = module.website_content.files
+  for_each = module.website_content.files
 
-    bucket = aws_s3_bucket.website.bucket
-    key = each.key
-    content_type = each.value.content_type
-    source  = each.value.source_path
+  bucket       = aws_s3_bucket.website.bucket
+  key          = each.key
+  content_type = each.value.content_type
+  source       = each.value.source_path
 
-    etag = each.value.digests.md5
-    acl    = "public-read"
+  etag = each.value.digests.md5
+  acl  = "public-read"
 
 }
 
 locals {
-    config_content = templatefile(var.config_js_template, 
-        {
-            user_pool_id = aws_cognito_user_pool.pool.id
-            user_pool_client_id = aws_cognito_user_pool_client.app_client.id
-            aws_region = var.default_aws_region
-            invoke_url = aws_api_gateway_stage.prod.invoke_url
-        }
-    )
+  config_content = templatefile(var.config_js_template,
+    {
+      user_pool_id        = aws_cognito_user_pool.pool.id
+      user_pool_client_id = aws_cognito_user_pool_client.app_client.id
+      aws_region          = var.default_aws_region
+      invoke_url          = aws_api_gateway_stage.prod.invoke_url
+    }
+  )
 }
 
 resource "aws_s3_object" "config_js" {
 
-    bucket = aws_s3_bucket.website.bucket
-    key    = var.config_js_output
-    content = local.config_content
-    content_type = "text/javascript"
-    etag = md5(local.config_content)
-    acl    = "public-read"
+  bucket       = aws_s3_bucket.website.bucket
+  key          = var.config_js_output
+  content      = local.config_content
+  content_type = "text/javascript"
+  etag         = md5(local.config_content)
+  acl          = "public-read"
 
-    depends_on = [
-      aws_s3_object.object          ## To avoid an accidental overwrite of config file
-    ]
+  depends_on = [
+    aws_s3_object.object ## To avoid an accidental overwrite of config file
+  ]
 }
 
 
 resource "aws_s3_bucket_website_configuration" "website" {
-    bucket = aws_s3_bucket.website.bucket
+  bucket = aws_s3_bucket.website.bucket
 
-    index_document {
-        suffix = "index.html"
-    }
+  index_document {
+    suffix = "index.html"
+  }
 
 }
 
 output "website_url" {
-    value = aws_s3_bucket_website_configuration.website.website_endpoint
+  value = aws_s3_bucket_website_configuration.website.website_endpoint
 }
 
 resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
-    bucket = aws_s3_bucket.website.id
-    policy = data.aws_iam_policy_document.website_policy.json
+  bucket = aws_s3_bucket.website.id
+  policy = data.aws_iam_policy_document.website_policy.json
 }
 
 data "aws_iam_policy_document" "website_policy" {


### PR DESCRIPTION
The Amazon S3 Block Public Access feature provides settings for access points, buckets, and accounts to help manage public access to Amazon S3 resources. By default, new buckets, access points, and objects don't allow public access. However, users can modify bucket policies, access point policies, or object permissions to allow public access. S3 Block Public Access settings override these policies and permissions to limit public access to these resources.