### PR TITLE
bugfix/accurics_remediation_8067736148579265 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/wordpress_ec2_alb_rds/database.tf
+++ b/demo-terraform/aws/wordpress_ec2_alb_rds/database.tf
@@ -1,44 +1,45 @@
 locals {
-    db_name = "db${random_string.lab_id.result}"
+  db_name = "db${random_string.lab_id.result}"
 
 }
 
 resource "aws_db_subnet_group" "sg" {
-    name       = lower("sng-${random_string.lab_id.result}")
-    subnet_ids = module.vpc.private_subnets
-    tags = {
-        Name = "sng-${random_string.lab_id.result}"
-        "Lab-ID" = random_string.lab_id.result
-    } 
+  name       = lower("sng-${random_string.lab_id.result}")
+  subnet_ids = module.vpc.private_subnets
+  tags = {
+    Name     = "sng-${random_string.lab_id.result}"
+    "Lab-ID" = random_string.lab_id.result
+  }
 
 }
 
 resource "aws_db_instance" "db" {
-    max_allocated_storage = 0 # Disable storage grow 
-    
-    allocated_storage = 10 # In gigabytes
-    storage_type = "gp2"
-    
-    engine = "mysql"
-    engine_version = "5.7"
-    instance_class = "db.t2.micro"
-    
-    name = local.db_name
-    username = "admin"
-    password = random_string.lab_id.result
-    
-    multi_az = true ## HA Deploiment in multi subnet
-    db_subnet_group_name = aws_db_subnet_group.sg.name
+  max_allocated_storage = 0 # Disable storage grow 
 
-    publicly_accessible = false
-    skip_final_snapshot = true
+  allocated_storage = 10 # In gigabytes
+  storage_type      = "gp2"
 
-    identifier = lower(local.db_name)
-    vpc_security_group_ids = [ aws_security_group.db.id ]
+  engine         = "mysql"
+  engine_version = "5.7"
+  instance_class = "db.t2.micro"
+
+  name     = local.db_name
+  username = "admin"
+  password = random_string.lab_id.result
+
+  multi_az             = true ## HA Deploiment in multi subnet
+  db_subnet_group_name = aws_db_subnet_group.sg.name
+
+  publicly_accessible = false
+  skip_final_snapshot = true
+
+  identifier             = lower(local.db_name)
+  vpc_security_group_ids = [aws_security_group.db.id]
 
 
-    tags = {
-        Name = local.db_name
-        "Lab-ID" = random_string.lab_id.result
-    } 
+  tags = {
+    Name     = local.db_name
+    "Lab-ID" = random_string.lab_id.result
+  }
+  backup_retention_period = 30
 }


### PR DESCRIPTION
Automated backups can be enabled using AWS Console or AWS CLI.
 In AWS Console - 
 1. Sign in to the AWS Console and go to the Amazon RDS console.
 2. Select Databases, and then choose the DB instance that you want to modify in the navigation pane.
 3. Select Modify.
 4. For Backup retention period, select the recommended 30 days value.
 5. Select Continue.
 6. Select Apply immediately.
 7. On the confirmation page, select Modify DB instance to save your changes and enable automated backups.
 Using AWS CLI - 
 Use the command : 'modify-db-instance' with the following parameters: 
   a.--db-instance-identifier 
   b. --backup-retention-period 
   c. --apply-immediately 
This will enable automated backups for AWS RDS instances.